### PR TITLE
Fixed bug with Array sum method.

### DIFF
--- a/lib/core_ext/array.rb
+++ b/lib/core_ext/array.rb
@@ -1,5 +1,9 @@
 class Array
-  def sum
-    inject( nil ) { |sum,x| sum ? sum+x : x }
+  def sum(identity = 0, &block)
+    if block_given?
+      map(&block).sum(identity)
+    else
+      inject(:+) || identity
+    end
   end
 end


### PR DESCRIPTION
After installing amnesia, adding it to my config.ru and starting my server again, I got this error :

```
undefined method `zero?' for nil:NilClass
```

I googled around and found [this is coming from your definition of the sum method for Array](http://stackoverflow.com/questions/8899272/rails-3-undefined-method-zero-for-nilnilclass-in-many-to-many-relationsh)

So I replaced Array sum method definition with the one in Rails's Enumerable. I don't know if the whole definition is needed but at least my app is now running fine.

I see you're using Ruby 1.9.2 and I'm still on 1.8.7 so this may be a 1.8.7 related issue.
Couldn't manage to run your tests to confirm it though.

Tell me if it's still working fine for you :)
