### PR TITLE
namespaced mount

### DIFF
--- a/lib/amnesia/views/index.haml
+++ b/lib/amnesia/views/index.haml
@@ -26,7 +26,7 @@
   - for host in @hosts
     - if host.alive?
       %li
-        %a{:href => "/amnesia/" + host.address }= host.address
+        %a{:href => url("/#{host.address}") }= host.address
     - else
       %li.inactive
         = host.address

--- a/lib/amnesia/views/layout.haml
+++ b/lib/amnesia/views/layout.haml
@@ -3,11 +3,11 @@
   %head
     %meta{:charset => "utf-8"}
     %title Amnesia
-    %link{:rel => "stylesheet", :href => "/amnesia/css/application.css"}
+    %link{:rel => "stylesheet", :href => url("/css/application.css")}
   %body
     %header
       %h1
-        %a{:href => '/amnesia'} Amnesia
+        %a{:href => url('/')} Amnesia
       %p Statistics for Memcached. Wait—What?
     %section#main
       = yield


### PR DESCRIPTION
if i mount anmesia in a rails namespace, assets and links won't work because they're hard coded.
eg, css would be loaded from `/amnesia/css/...` instead of `/admin/amnesia/css/...`:

``` ruby
namespace :admin do
  mount Amnesia::Application.new => "/amnesia", as: :amnesia
end
```

this patch makes link generation dynamic by using sinatra's [url helper](http://www.sinatrarb.com/intro.html#Generating%20URLs).
