### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -103,7 +103,7 @@ Within my slices, I punched a hole through `iptables`
 
 You won't need to do this unless you've explicitly blocked ports to your server. (When in doubt, block nearly everything)
 
-Let me know if you come accross any issues using Github messaging.
+Let me know if you come across any issues using Github messaging.
 
 ## Something missing? 
 


### PR DESCRIPTION
@benschwarz, I've corrected a typographical error in the documentation of the [amnesia](https://github.com/benschwarz/amnesia) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.