### PR TITLE
load google charts with tls

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,6 +90,19 @@ on heroku, like this:
 
     heroku config:add AMNESIA_CREDS=ben:schwarz
 
+### Content Security Policy
+
+Amnesia uses Google Charts to display pie charts. In case you're employing
+a CSP header you'll need to add the Google Chart servers as a valid image source, e.g.:
+
+    Content-Security-Policy: img-src 'self' data: https: https://chart.apis.google.com;
+
+Within a Rack app you can use [Rack::Protection](http://www.sinatrarb.com/protection):
+
+```rb
+use Rack::Protection::ContentSecurityPolicy, img-src: "'self' data: https: https://chart.apis.google.com"
+```
+
 ## Potential issues
 
 * Hosts are listed as "Inactive" or "Not Responding"

--- a/lib/amnesia/helpers.rb
+++ b/lib/amnesia/helpers.rb
@@ -10,7 +10,7 @@ module Amnesia
       SIZE_UNITS = %w[ Bytes KB MB GB TB PB EB ]
 
       def graph_url(*data)
-        Gchart.pie(data: data, size: '115x115', bg: 'ffffff00')
+        Gchart.pie(data: data, size: '115x115', bg: 'ffffff00', use_ssl: true)
       end
 
       # https://github.com/rails/rails/blob/fbe335cfe09bf0949edfdf0c4b251f4d081bd5d7/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb


### PR DESCRIPTION
- always load charts from `https://...`
- note possibly required content security policy configuration in readme