### PR TITLE
improve wording regarding available memory

### DIFF
--- a/lib/amnesia/views/host.haml
+++ b/lib/amnesia/views/host.haml
@@ -10,8 +10,8 @@
   %section.stats-text
     %h3
       %span.graph-indicator Used Memory (#{number_to_human_size(@host.bytes)})
-      \/ Free Memory (#{number_to_human_size(@host.limit_maxbytes)})
-    %p The cumulative amount of free memory and total memory across all active hosts.
+      \/ Available Memory (#{number_to_human_size(@host.limit_maxbytes)})
+    %p The cumulative amount of available memory across all active hosts.
 
 %article.stats
   %section.stats-graph

--- a/lib/amnesia/views/host.haml
+++ b/lib/amnesia/views/host.haml
@@ -9,7 +9,7 @@
     %img{src: graph_url(@host.bytes, @host.limit_maxbytes) }
   %section.stats-text
     %h3
-      %span.graph-indicator Used Memory (#{number_to_human_size(@host.bytes)})
+      %span.graph-indicator Used (#{number_to_human_size(@host.bytes)})
       \/ Available Memory (#{number_to_human_size(@host.limit_maxbytes)})
     %p The cumulative amount of available memory across all active hosts.
 

--- a/lib/amnesia/views/index.haml
+++ b/lib/amnesia/views/index.haml
@@ -4,7 +4,7 @@
       %img{src: graph_url(bytes_sum, limit_maxbytes_sum)}
     %section.stats-text
       %h3
-        %span.graph-indicator Used Memory (#{number_to_human_size(bytes_sum)})
+        %span.graph-indicator Used (#{number_to_human_size(bytes_sum)})
         \/ Available Memory (#{number_to_human_size(limit_maxbytes_sum)})
       %p The cumulative amount of available memory across all active hosts.
 

--- a/lib/amnesia/views/index.haml
+++ b/lib/amnesia/views/index.haml
@@ -5,8 +5,8 @@
     %section.stats-text
       %h3
         %span.graph-indicator Used Memory (#{number_to_human_size(bytes_sum)})
-        \/ Free Memory (#{number_to_human_size(limit_maxbytes_sum)})
-      %p The cumulative amount of free memory and total memory across all active hosts.
+        \/ Available Memory (#{number_to_human_size(limit_maxbytes_sum)})
+      %p The cumulative amount of available memory across all active hosts.
 
   %article.stats
     %section.stats-graph


### PR DESCRIPTION
the wording is a little unfit, i think:

<img width="463" src="https://user-images.githubusercontent.com/201135/85740604-0b8f9c00-b702-11ea-8613-d22b86aa08fe.png">

if 50mb are in use, 64mb of available memory isn't actually free anymore ;)
replaced "free" with "available".