### PR TITLE
fix haml

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5.x', '2.6.x', '2.7.x' ]
+        ruby: [ '2.5', '2.6', '2.7' ]
     steps:
     - name: Install memcache
       run: |
@@ -16,21 +16,9 @@ jobs:
     - name: Start memcached
       run: memcached -d
     - uses: actions/checkout@v1
-    - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Cache gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/*.gemspec') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.ruby }}-gems-
-    - name: Install gems
-      run: |
-        gem install bundler
-        bundle config path vendor/bundle
-        bundle check || bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - name: Run tests
       run: bundle exec rspec

--- a/amnesia.gemspec
+++ b/amnesia.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "amnesia"
-  s.version     = "1.1.0"
+  s.version     = "1.2.0"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Ben Schwarz"]
   s.email       = ["ben.schwarz@gmail.com"]

--- a/amnesia.gemspec
+++ b/amnesia.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob("{bin,lib}/**/*") + %w(LICENCE README.markdown)
   s.require_path = 'lib'
 
-  s.add_dependency "sinatra"
+  s.add_dependency "sinatra", "> 1"
   s.add_dependency "dalli"
   s.add_dependency "haml"
 

--- a/lib/amnesia/views/layout.haml
+++ b/lib/amnesia/views/layout.haml
@@ -10,7 +10,7 @@
         %a{href: url('/')} Amnesia
       %p Statistics for Memcached. Wait—What?
     %main
-      = yield
+      != yield
     %footer
       %p
         Another


### PR DESCRIPTION
version 1.1.0 is broken with haml 6 because it escapes html by default.

please release as 1.2.0.

i have a follow-up to support newer rubies.